### PR TITLE
Fix dead link: pattern matching in Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Functional Pattern Matching in JavaScript
 
-Pattern matching is a form of conditional branching which allows you to concisely match on data structure patterns and bind variables at the same time ( [Wikipedia](http://en.wikipedia.org/wiki/Conditional_statement#Pattern_matching)). Pattern matching is supported in some functional languages such as ML, Haskell, OCaml, and Erlang. This library implements pattern matching for the JavaScript language in an efficient and concise way. The following example shows what pattern matching in JavaScript looks like:
+Pattern matching is a form of conditional branching which allows you to concisely match on data structure patterns and bind variables at the same time ( [Wikipedia](https://en.wikipedia.org/wiki/Conditional_(computer_programming)#Pattern_matching)). Pattern matching is supported in some functional languages such as ML, Haskell, OCaml, and Erlang. This library implements pattern matching for the JavaScript language in an efficient and concise way. The following example shows what pattern matching in JavaScript looks like:
 
     var fact = fun(
         [0, () =>  1],


### PR DESCRIPTION
The current link for pattern matching in README.md is dead.